### PR TITLE
Updated get_example_data function so that it installs Osiris_Data_test

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Depends: R (>= 2.10)
 License: BSD_2_clause + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Imports: 
 	dplyr,
 	data.table,

--- a/R/get_example_data.R
+++ b/R/get_example_data.R
@@ -1,10 +1,10 @@
 #' get_example_data
 #'
-#' Function to download the data files from zenodo that are needed to run Osiris.
+#' Function to download the test data files from zenodo that are needed to run Osiris.
 #'
 #' @param write_dir Default = getwd()
-#' @param dir_name = "Osiris_Data". Name of directory to install zip file to.
-#' @param data_link Default = "https://zenodo.org/record/7474112/files/Osiris_Data.zip?download=1"
+#' @param dir_name = "Osiris_Data_Test". Name of directory to install zip file to.
+#' @param data_link Default = "https://zenodo.org/record/7530067/files/Osiris_Data_Test.zip?download=1"
 #' @keywords test
 #' @return number
 #' @importFrom rlang :=
@@ -17,8 +17,8 @@
 #' }
 
 get_example_data <- function(write_dir = getwd(),
-                             dir_name = "Osiris_Data",
-                             data_link = "https://zenodo.org/record/7474112/files/Osiris_Data.zip?download=1") {
+                             dir_name = "Osiris_Data_Test",
+                             data_link = "https://zenodo.org/record/7530067/files/Osiris_Data_Test.zip?download=1") {
 
 
   #.........................

--- a/man/get_example_data.Rd
+++ b/man/get_example_data.Rd
@@ -6,22 +6,22 @@
 \usage{
 get_example_data(
   write_dir = getwd(),
-  dir_name = "Osiris_Data",
-  data_link = "https://zenodo.org/record/7474112/files/Osiris_Data.zip?download=1"
+  dir_name = "Osiris_Data_Test",
+  data_link = "https://zenodo.org/record/7530067/files/Osiris_Data_Test.zip?download=1"
 )
 }
 \arguments{
 \item{write_dir}{Default = getwd()}
 
-\item{dir_name}{= "Osiris_Data". Name of directory to install zip file to.}
+\item{dir_name}{= "Osiris_Data_Test". Name of directory to install zip file to.}
 
-\item{data_link}{Default = "https://zenodo.org/record/7474112/files/Osiris_Data.zip?download=1"}
+\item{data_link}{Default = "https://zenodo.org/record/7530067/files/Osiris_Data_Test.zip?download=1"}
 }
 \value{
 number
 }
 \description{
-Function to download the data files from zenodo that are needed to run Osiris.
+Function to download the test data files from zenodo that are needed to run Osiris.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
The original function had the zenodo link to the full data set.